### PR TITLE
bump base image version to oldest still available/supported, 8.12=>10.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12-alpine
+FROM node:10.21-alpine
 
 RUN adduser -S www-data
 


### PR DESCRIPTION
Creating this PR to document the build failure.