### PR TITLE
Use GBIF endpoints for collections

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -5,6 +5,7 @@ var config = {
   env: process.env.NODE_ENV,
   api: 'https://search.idigbio.org/v2/',
   media: 'https://api.idigbio.org/',
+  gbifApi: 'https://api.gbif-uat.org/v1/', // TODO - currently pointing to UAT test env.
   secret: process.env.IDB_SECRET || "imnotsecret",
   root: path.normalize(path.join(__dirname, '..')),
   app: {


### PR DESCRIPTION
Hi
I've created a small pull request to see if we could get something working just by using the GBIF registry as a datasource instead of the Github files with collections.

This is really just intended as a proof of concept in anticipation of our meeting tomorrow. I wasn't able to run it locally I'm afraid, but this was the simplest idea we could come up with for an initial integration.
Thanks